### PR TITLE
Add Vitest tests with mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Testing
+
+Run unit tests with:
+
+```bash
+pnpm test
+```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -38,7 +39,8 @@
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.5.0"
   },
   "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
 }

--- a/tests/searchPDFsByQuery.test.ts
+++ b/tests/searchPDFsByQuery.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let rpcMock: any;
+let embeddingsCreateMock: any;
+
+vi.mock('@supabase/supabase-js', () => {
+  rpcMock = vi.fn().mockResolvedValue({ data: [{ id: '1' }], error: null });
+  return {
+    createClient: vi.fn(() => ({
+      rpc: rpcMock,
+    })),
+  };
+});
+
+class MockOpenAI {
+  embeddings = { create: embeddingsCreateMock };
+}
+
+vi.mock('openai', () => {
+  embeddingsCreateMock = vi.fn().mockResolvedValue({ data: [{ embedding: [1, 2, 3] }] });
+  return {
+    OpenAI: vi.fn(() => new MockOpenAI()),
+  };
+});
+
+describe('searchPDFsByQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns matching documents', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://test';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+    process.env.OPENAI_API_KEY = 'key';
+
+    const { searchPDFsByQuery } = await import('../src/actions/searchPDFsByQuery');
+    const result = await searchPDFsByQuery('hello');
+
+    expect(embeddingsCreateMock).toHaveBeenCalled();
+    expect(rpcMock).toHaveBeenCalled();
+    expect(result).toEqual({ results: [{ id: '1' }] });
+  });
+});

--- a/tests/uploadAndEmbedPDF.test.ts
+++ b/tests/uploadAndEmbedPDF.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let uploadMock: any;
+let getPublicUrlMock: any;
+let insertMock: any;
+let rpcMock: any;
+
+let embeddingsCreateMock: any;
+let chatCreateMock: any;
+
+vi.mock('@supabase/supabase-js', () => {
+  uploadMock = vi.fn().mockResolvedValue({ error: null });
+  getPublicUrlMock = vi.fn().mockReturnValue({ data: { publicUrl: 'https://supabase.test/file.pdf' } });
+  insertMock = vi.fn().mockResolvedValue({ error: null });
+  rpcMock = vi.fn();
+  return {
+    createClient: vi.fn(() => ({
+      storage: {
+        from: vi.fn(() => ({
+          upload: uploadMock,
+          getPublicUrl: getPublicUrlMock,
+        })),
+      },
+      from: vi.fn(() => ({ insert: insertMock })),
+      rpc: rpcMock,
+    })),
+  };
+});
+
+class MockOpenAI {
+  embeddings = { create: embeddingsCreateMock };
+  chat = { completions: { create: chatCreateMock } };
+}
+
+vi.mock('openai', () => {
+  embeddingsCreateMock = vi.fn().mockResolvedValue({ data: [{ embedding: [1, 2, 3] }] });
+  chatCreateMock = vi.fn().mockResolvedValue({ choices: [{ message: { content: 'Title: Test\nDescription: Example' } }] });
+  return {
+    OpenAI: vi.fn(() => new MockOpenAI()),
+  };
+});
+
+vi.mock('pdf-parse', () => ({ default: vi.fn(async () => ({ text: 'pdf text' })) }));
+
+describe('uploadAndEmbedPDF', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uploads file and stores embedding', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://test';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+    process.env.OPENAI_API_KEY = 'key';
+
+    const { uploadAndEmbedPDF } = await import('../src/actions/uploadAndEmbedPDF');
+    const formData = new FormData();
+    const file = new File(['dummy'], 'test.pdf', { type: 'application/pdf' });
+    formData.set('file', file);
+
+    const result = await uploadAndEmbedPDF(formData);
+
+    expect(uploadMock).toHaveBeenCalled();
+    expect(insertMock).toHaveBeenCalled();
+    expect(result).toEqual({
+      success: true,
+      title: 'Test',
+      description: 'Example',
+      url: 'https://supabase.test/file.pdf',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest and test script
- mock Supabase and OpenAI APIs for tests
- test uploadAndEmbedPDF
- test searchPDFsByQuery
- document testing in README

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447634de908321be927973640fee25